### PR TITLE
Compile using libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,11 @@ setup: setup-ci  # prepares this codebase
 	cargo install cargo-edit cargo-upgrades --locked
 	echo
 	echo PLEASE DO THIS MANUALLY:
-	echo 1. install musl, e.g. "sudo apt install musl"
-	echo 2. install openssl-devel:
+	echo 1. install openssl-devel:
 	echo    - Fedora: sudo dnf install openssl-devel
 	echo    - Debian: sudo apt install libssl-dev pkg-config
-	echo 3. cargo install cargo-edit
-	echo 4. cargo install dprint
+	echo 2. cargo install cargo-edit
+	echo 3. cargo install dprint
 
 setup-ci:  # prepares the CI server
 # cargo install cargo-udeps --locked  # requires nightly

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 RUN_THAT_APP_VERSION = 0.5.0
 
 build:  # builds the release binary
-	cargo build --release --target x86_64-unknown-linux-musl
+	cargo build --release
 
 build-release:  # builds a release version of the binary
 	docker run --rm --user "$(id -u)":"$(id -g)" -v "$(PWD)":/usr/src/myapp -w /usr/src/myapp rust cargo build --release


### PR DESCRIPTION
`musl` is for embedded environments, which we don't target. We have a way to compile with an older libc for release.